### PR TITLE
feat: improve merge types and add max recursion depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - API-Friendly
 
 <blockquote>
-  <sub><strong>Package size</strong>: <code>~500 B</code> minified, <code>~360 B</code> gzip</sub>
+  <sub><strong>Package size</strong>: <code>~560 B</code> minified, <code>~370 B</code> gzip</sub>
 </blockquote>
 
 ## Core Concepts
@@ -36,6 +36,7 @@
 - **Deep-merge**: Recursively combines multiple objects into a unified result.
 - **Type-safe**: Automatically infers types from all specified sources.
 - **Merge Rules**: Offers precise control over merging strategies.
+- **Depth Limit**: Provides maximum recursion depth when merging nested objects.
 
 ## Installation
 
@@ -102,6 +103,8 @@ const result = merge([A, B, C, D])
 const resultRules = merge([A, B, C, D], {
   rules: { array: 'override', undefined: 'skip', null: 'skip' },
 })
+
+const resultDepth = merge([A, B, C, D], { depth: 1 })
 ```
 
 **Output: result**
@@ -111,11 +114,11 @@ const resultRules = merge([A, B, C, D], {
 {
   a: 'merge',
   b: {
-    c: { d: [ 1, 2, 3, '4', '5', '6' ] },
+    c: { d: [1, 2, 3, '4', '5', '6'] },
     e: { f: { g: 33 } },
-    h: [ 23, 33 ]
+    h: [23, 33],
   },
-  i: { j: undefined, k: null }
+  i: { j: undefined, k: null },
 }
 ```
 
@@ -147,8 +150,8 @@ const resultRules = merge([A, B, C, D], {
 // Merged Result With Custom Rules
 {
   a: 'merge',
-  b: { c: { d: [ '4', '5', '6' ] }, e: { f: { g: 33 } }, h: [ 23, 33 ] },
-  i: { j: 77, k: 99 }
+  b: { c: { d: ['4', '5', '6'] }, e: { f: { g: 33 } }, h: [23, 33] },
+  i: { j: 77, k: 99 },
 }
 ```
 
@@ -170,6 +173,33 @@ const resultRules = merge([A, B, C, D], {
   i: {
     j: number
     k: number
+  }
+}
+```
+
+**Output: resultDepth**
+
+```ts
+// Merged Result With Custom Depth
+{
+  a: 'merge',
+  b: { c: {}, e: {}, h: [23, 33] },
+  i: { j: undefined, k: null },
+}
+```
+
+```ts
+// Automatically Infered Types
+{
+  a: string
+  b: {
+    c: unknown
+    e: unknown
+    h: number[]
+  }
+  i: {
+    j: undefined
+    k: null
   }
 }
 ```
@@ -291,6 +321,21 @@ const B = { a: null }
 
 const resultOverride = merge([A, B], { rules: { null: 'override' } }) // => { a: null }
 const resultSkip = merge([A, B], { rules: { null: 'skip' } }) // => { a: 'hello' }
+```
+
+### depth
+
+- Type: `number`
+- Default: `6`
+
+Specifies the maximum recursion depth when merging nested objects.
+
+The depth counter is a safeguard that limits recursion, improving compiler performance, and prevents possible infinite type instantiation issues during type-checking.
+
+In most cases, you won't need to change this.
+
+```ts
+const resultDepth = merge([A, B], { depth: 3 })
 ```
 
 ## Community

--- a/playground/merge.ts
+++ b/playground/merge.ts
@@ -48,5 +48,8 @@ const resultRules = merge([A, B, C, D], {
   rules: { array: 'override', undefined: 'skip', null: 'skip' },
 })
 
+const resultDepth = merge([A, B, C, D], { depth: 1 })
+
 console.log('result:', inspect(result, { depth: 3, colors: true }))
 console.log('resultRules:', inspect(resultRules, { depth: 3, colors: true }))
+console.log('resultDepth:', inspect(resultDepth, { depth: 3, colors: true }))

--- a/playground/types.ts
+++ b/playground/types.ts
@@ -1,6 +1,6 @@
 import type { Merge } from '@/types'
 
-type A = {
+type A1 = {
   a: boolean
   b: {
     c: {
@@ -12,7 +12,7 @@ type A = {
   }
 }
 
-type B = {
+type B1 = {
   a: string
   b: {
     c: {
@@ -27,23 +27,62 @@ type B = {
   }
 }
 
-type C = {
+type C1 = {
   i: {
     j: number
     k: number
   }
 }
 
-type D = {
+type D1 = {
   i: {
     j?: undefined
     k?: null
   }
 }
 
-export type Result = Merge<[A, B, C, D]>
+export type ResultDefault = Merge<[A1, B1, C1, D1]>
 
 export type ResultRules = Merge<
-  [A, B, C, D],
-  { rules: { array: 'override'; undefined: 'skip'; null: 'skip' } }
+  [A1, B1, C1, D1],
+  {
+    rules: { array: 'override'; undefined: 'skip'; null: 'skip' }
+  }
 >
+
+type A2 = {
+  a: boolean[]
+  b: {
+    c: {
+      d: string
+      e: {
+        f: number
+      }
+    }
+  }
+  d: boolean
+  e: {
+    f: string
+    g: number[]
+  }
+}
+
+type B2 = {
+  a?: string[]
+  b: {
+    a: number
+  }
+  d: number
+  e: {
+    f: number[]
+    g?: string
+  }
+}
+
+type C2 = {
+  i?: string | null
+}
+
+export type ResultDepth0 = Merge<[A2, B2, C2], { depth: 0 }>
+
+export type ResultDepth1 = Merge<[A2, B2, C2], { depth: 1 }>

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -2,48 +2,201 @@ import type { Merge } from '@/types'
 import { describe, test, expectTypeOf } from 'vitest'
 
 describe('Merge Types', () => {
-  type A = {
-    a: boolean
-    b: {
-      c: {
-        d: number[]
-      }
-      e: {
-        f: boolean
+  test('should override values correctly', () => {
+    type A = {
+      a: string
+      b: number
+      c: boolean
+      d: bigint
+      e: symbol
+      f: Date
+      g: () => void
+      h: boolean[]
+      i: {
+        j: string
+        k: boolean
+        l: number
       }
     }
-  }
 
-  type B = {
-    a: string
-    b: {
+    type B = {
+      a: boolean
+      b: string
+      c: number
+      d: Date
+      e: () => void
+      f: symbol
+      g: bigint
+      h: object
+      i: string[]
+    }
+
+    type Result = Merge<[A, B]>
+
+    expectTypeOf<Result>().toEqualTypeOf<B>()
+  })
+
+  test('should handle undefined and null correctly', () => {
+    type A = {
+      a?: string
+      b?: number
       c: {
-        d?: string[]
+        d?: boolean[]
+        e?: string
       }
-      e: {
-        f: {
-          g: number
+      f: string[]
+    }
+
+    type B = {
+      a?: undefined
+      b?: null
+    }
+
+    type C = {
+      c: undefined
+      f: null
+    }
+
+    type Result = Merge<[A, B, C]>
+
+    expectTypeOf<Result>().toEqualTypeOf<{
+      a: undefined
+      b: null | undefined
+      c: undefined
+      f: null
+    }>()
+
+    type ResultUndefinedSkip = Merge<
+      [A, B, C],
+      { rules: { undefined: 'skip' } }
+    >
+
+    expectTypeOf<ResultUndefinedSkip>().toEqualTypeOf<{
+      a: string
+      b: null
+      c: {
+        d: boolean[]
+        e: string
+      }
+      f: null
+    }>()
+
+    type ResultNullSkip = Merge<[A, B, C], { rules: { null: 'skip' } }>
+
+    expectTypeOf<ResultNullSkip>().toEqualTypeOf<{
+      a: undefined
+      b: undefined
+      c: undefined
+      f: string[]
+    }>()
+  })
+
+  test('should handle arrays correctly', () => {
+    type A = {
+      a?: string[]
+      b: (number | null | undefined)[]
+      c: undefined[]
+      d: null[]
+      e?: boolean[]
+    }
+
+    type B = {
+      a?: (number | boolean)[]
+      b?: string[]
+      c?: boolean[]
+      d: (object | Date)[]
+      e?: symbol[]
+    }
+
+    type ResultCombine = Merge<[A, B], { rules: { array: 'combine' } }>
+
+    expectTypeOf<ResultCombine>().toEqualTypeOf<{
+      a: (string | number | boolean)[] | undefined
+      b: (string | number | null | undefined)[] | undefined
+      c: (boolean | undefined)[] | undefined
+      d: (object | Date | null)[]
+      e: (boolean | symbol)[] | undefined
+    }>()
+
+    type ResultCombineSkip = Merge<
+      [A, B],
+      { rules: { array: 'combine'; undefined: 'skip'; null: 'skip' } }
+    >
+
+    expectTypeOf<ResultCombineSkip>().toEqualTypeOf<{
+      a: (string | number | boolean)[]
+      b: (string | number | null | undefined)[]
+      c: (boolean | undefined)[]
+      d: (object | Date | null)[]
+      e: (boolean | symbol)[]
+    }>()
+
+    type ResultOverride = Merge<[A, B], { rules: { array: 'override' } }>
+
+    expectTypeOf<ResultOverride>().toEqualTypeOf<{
+      a: (number | boolean)[] | undefined
+      b: string[] | undefined
+      c: boolean[] | undefined
+      d: (object | Date)[]
+      e: symbol[] | undefined
+    }>()
+
+    type ResultOverrideSkip = Merge<
+      [A, B],
+      { rules: { array: 'override'; undefined: 'skip'; null: 'skip' } }
+    >
+
+    expectTypeOf<ResultOverrideSkip>().toEqualTypeOf<{
+      a: (number | boolean)[]
+      b: string[]
+      c: boolean[]
+      d: (object | Date)[]
+      e: symbol[]
+    }>()
+  })
+
+  test('should create a deep merged interface', () => {
+    type A = {
+      a: boolean
+      b: {
+        c: {
+          d: number[]
+        }
+        e: {
+          f: boolean
         }
       }
-      h?: number[]
     }
-  }
 
-  type C = {
-    i: {
-      j: number
-      k: number
+    type B = {
+      a: string
+      b: {
+        c: {
+          d?: string[]
+        }
+        e: {
+          f: {
+            g: number
+          }
+        }
+        h?: number[]
+      }
     }
-  }
 
-  type D = {
-    i: {
-      j?: undefined
-      k?: null
+    type C = {
+      i: {
+        j: number
+        k: number
+      }
     }
-  }
 
-  test('should create a merged interface', () => {
+    type D = {
+      i: {
+        j?: undefined
+        k?: null
+      }
+    }
+
     type Result = Merge<[A, B, C, D]>
 
     expectTypeOf<Result>().toEqualTypeOf<{
@@ -67,14 +220,55 @@ describe('Merge Types', () => {
   })
 
   test('should create a merged interface with custom rules', () => {
-    type ResultRules = Merge<
+    type A = {
+      a: boolean
+      b: {
+        c: {
+          d: number[]
+        }
+        e: {
+          f: boolean
+        }
+      }
+    }
+
+    type B = {
+      a: string
+      b: {
+        c: {
+          d?: string[]
+        }
+        e: {
+          f: {
+            g: number
+          }
+        }
+        h?: number[]
+      }
+    }
+
+    type C = {
+      i: {
+        j: number
+        k: number
+      }
+    }
+
+    type D = {
+      i: {
+        j?: undefined
+        k?: null
+      }
+    }
+
+    type Result = Merge<
       [A, B, C, D],
       {
         rules: { array: 'override'; undefined: 'skip'; null: 'skip' }
       }
     >
 
-    expectTypeOf<ResultRules>().toEqualTypeOf<{
+    expectTypeOf<Result>().toEqualTypeOf<{
       a: string
       b: {
         c: {
@@ -90,6 +284,107 @@ describe('Merge Types', () => {
       i: {
         j: number
         k: number
+      }
+    }>()
+  })
+
+  test('should handle depth correctly', () => {
+    type A = {
+      a: boolean[]
+      b: {
+        c: {
+          d: string
+          e: {
+            f: number
+          }
+        }
+      }
+      d: boolean
+      e: {
+        f: string
+        g: number[]
+      }
+    }
+
+    type B = {
+      a?: string[]
+      b: {
+        a: number
+      }
+      d: number
+      e: {
+        f: number[]
+        g?: string
+      }
+    }
+
+    type C = {
+      i?: string | null
+    }
+
+    type ResultDepth0 = Merge<[A, B, C], { depth: 0 }>
+
+    expectTypeOf<ResultDepth0>().toEqualTypeOf<{
+      a: string[] | undefined
+      b: unknown
+      d: number
+      e: unknown
+      i: string | null | undefined
+    }>()
+
+    type ResultDepth1 = Merge<[A, B, C], { depth: 1 }>
+
+    expectTypeOf<ResultDepth1>().toEqualTypeOf<{
+      a: (string | boolean)[] | undefined
+      b: {
+        a: number
+        c: unknown
+      }
+      d: number
+      e: {
+        f: number[]
+        g: string | undefined
+      }
+      i: string | null | undefined
+    }>()
+
+    type ResultDepth2 = Merge<[A, B, C], { depth: 2 }>
+
+    expectTypeOf<ResultDepth2>().toEqualTypeOf<{
+      a: (string | boolean)[] | undefined
+      b: {
+        a: number
+        c: {
+          d: string
+          e: unknown
+        }
+      }
+      i: string | null | undefined
+      d: number
+      e: {
+        f: number[]
+        g: string | undefined
+      }
+    }>()
+
+    type ResultDepth3 = Merge<[A, B, C], { depth: 3 }>
+
+    expectTypeOf<ResultDepth3>().toEqualTypeOf<{
+      a: (string | boolean)[] | undefined
+      b: {
+        a: number
+        c: {
+          d: string
+          e: {
+            f: number
+          }
+        }
+      }
+      i: string | null | undefined
+      d: number
+      e: {
+        f: number[]
+        g: string | undefined
       }
     }>()
   })


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types
- [x] Tests
- [x] Documentation

## Request Description

Adds a new `depth` option.

Also improves merge types and adds new tests.

Feel free to check out the playground, as well as the tests, for more examples.

### depth

Specifies the maximum recursion depth when merging nested objects.

The depth counter is a safeguard that limits recursion, improving compiler performance, and prevents possible infinite type instantiation issues during type-checking.

In most cases, you won't need to change this.

```ts
const A = {
  a: true,
  b: {
    c: {
      d: [1, 2, 3],
    },
    e: {
      f: true,
    },
  },
}

const B = {
  a: 'merge',
  b: {
    c: {
      d: ['4', '5', '6'],
    },
    e: {
      f: {
        g: 33,
      },
    },
    h: [23, 33],
  },
}

const C = {
  i: {
    j: 77,
    k: 99,
  },
}

const D = {
  i: {
    j: undefined,
    k: null,
  },
}

const resultDepth = merge([A, B, C, D], { depth: 1 })
```


**Output: resultDepth**

```ts
// Merged Result With Custom Depth
{
  a: 'merge',
  b: { c: {}, e: {}, h: [23, 33] },
  i: { j: undefined, k: null },
}
```

```ts
// Automatically Infered Types
{
  a: string
  b: {
    c: unknown
    e: unknown
    h: number[]
  }
  i: {
    j: undefined
    k: null
  }
}
```