### PR TITLE
feat: allow source to accept type undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { isObject, isArray, isUndefined, isNull } from '@hypernym/utils'
-import type { MergeRecord, MergeOptions, Merge } from './types'
+import type { MergeSource, MergeOptions, Merge } from './types'
 
 /**
  * Type-safe deep merge utility.
@@ -18,13 +18,13 @@ import type { MergeRecord, MergeOptions, Merge } from './types'
  *
  * @see [Repository](https://github.com/hypernym-studio/merge)
  */
-export function merge<T extends MergeRecord[], O extends MergeOptions>(
+export function merge<T extends MergeSource[], O extends MergeOptions>(
   sources: [...T],
   options?: O & MergeOptions & { depth?: O['depth'] },
 ): Merge<T, O> {
   const { rules, depth = 6 } = options || {}
 
-  return sources.reduce((prev: MergeRecord, curr: MergeRecord) => {
+  return sources.reduce((prev: MergeSource, curr: MergeSource) => {
     if (prev && curr) {
       Object.keys(curr).forEach((key) => {
         if (['__proto__', 'constructor', 'prototype'].includes(key)) return

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,9 @@ type LastSource<T extends any[], K extends PropertyKey> = T extends [
     : LastSource<R, K>
   : never
 
-type ExtractValue<T extends MergeRecord[], K extends PropertyKey> = T extends [
-  infer F extends MergeRecord,
-  ...infer R extends MergeRecord[],
+type ExtractValue<T extends MergeSource[], K extends PropertyKey> = T extends [
+  infer F extends MergeSource,
+  ...infer R extends MergeSource[],
 ]
   ? K extends keyof F
     ? [F[K], ...ExtractValue<R, K>]
@@ -25,21 +25,19 @@ type SkipRules<O extends MergeOptions> =
   | (O['rules'] extends { null: 'skip' } ? null : never)
 
 type LastValue<
-  T extends MergeRecord[],
+  T extends MergeSource[],
   K extends PropertyKey,
   O extends MergeOptions,
 > = T extends [...infer R, infer L]
-  ? L extends MergeRecord
-    ? K extends keyof L
-      ? Exclude<L[K], SkipRules<O>> extends never
-        ? LastValue<R extends MergeRecord[] ? R : [], K, O>
-        : Exclude<L[K], SkipRules<O>>
-      : LastValue<R extends MergeRecord[] ? R : [], K, O>
-    : LastValue<R extends MergeRecord[] ? R : [], K, O>
+  ? K extends keyof L
+    ? Exclude<L[K], SkipRules<O>> extends never
+      ? LastValue<R extends MergeSource[] ? R : [], K, O>
+      : Exclude<L[K], SkipRules<O>>
+    : LastValue<R extends MergeSource[] ? R : [], K, O>
   : never
 
 type ArrayValue<
-  T extends MergeRecord[],
+  T extends MergeSource[],
   K extends PropertyKey,
   O extends MergeOptions,
 > = O['rules'] extends { array: 'override' }
@@ -67,6 +65,8 @@ export type MergePrimitives =
 
 export type MergeRecord = Record<PropertyKey, any>
 
+export type MergeSource = MergeRecord | undefined
+
 export type MergeAllKeys<T extends any[]> = T extends [infer K, ...infer R]
   ? keyof K | MergeAllKeys<R extends any[] ? R : []>
   : never
@@ -74,7 +74,7 @@ export type MergeAllKeys<T extends any[]> = T extends [infer K, ...infer R]
 export type MergeArray<T> = T extends any[] ? T[number] : never
 
 export type MergeValue<
-  T extends MergeRecord[],
+  T extends MergeSource[],
   K extends PropertyKey,
   O extends MergeOptions,
 > = O['depth'] extends 0
@@ -104,14 +104,14 @@ export type MergeExpand<T> = T extends infer U
   : never
 
 export type MergeTypes<
-  T extends MergeRecord[],
+  T extends MergeSource[],
   O extends MergeOptions = MergeOptions,
 > = MergeExpand<{
   [K in MergeAllKeys<T>]: Exclude<MergeValue<T, K, O>, SkipRules<O>>
 }>
 
 export type Merge<
-  T extends MergeRecord[],
+  T extends MergeSource[],
   O extends MergeOptions = MergeOptions,
 > = MergeTypes<T, O>
 


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Types

## Request Description

Allows `sources` to accept `undefined` type in a non-disruptive way, meaning that sources can now contain defined types, but also undefined, which was not the case before.

This will improve the dev experience and make merging easier.

```ts
const A: { i: number } | undefined = { i: 33 }
const B: { d: boolean } | undefined = { d: true }
const C: { g: string } | undefined = undefined

const result = merge([A, B, C])

// returns: { i: 33, d: true }
// infers: { i: number; d: boolean; }
```